### PR TITLE
DEV-111 warnings_as_errors removed for compile with deprecated gen_fs…

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {lib_dirs, ["deps"]}.
 
-{erl_opts, [debug_info]}.
+{erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_function]}.
 
 {deps, [{common_lib, "3.3.6",
          {git, "git://github.com/platbox/common_lib.git", {tag, "3.3.6"}}}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,9 @@
 {lib_dirs, ["deps"]}.
 
-{erl_opts, [warnings_as_errors, debug_info]}.
+{erl_opts, [debug_info]}.
 
-{deps, [{common_lib, "3.3.5",
-         {git, "git://github.com/platbox/common_lib.git", {tag, "3.3.5"}}}]}.
+{deps, [{common_lib, "3.3.6",
+         {git, "git://github.com/platbox/common_lib.git", {tag, "3.3.6"}}}]}.
 
 {erl_first_files, ["src/gen_esme_session.erl",
                    "src/gen_mc_session.erl",


### PR DESCRIPTION
…m. Common libs tag changed for erlang 22